### PR TITLE
Smooth out hue transitions.

### DIFF
--- a/src/Kaleidoscope/LED-Wavepool.h
+++ b/src/Kaleidoscope/LED-Wavepool.h
@@ -31,6 +31,9 @@ class WavepoolEffect : public LEDMode {
 
   // ms before idle animation starts after last keypress
   static uint16_t idle_timeout;
+  // initial hue at keyboard boot, or all the time if CONSTANT_HUE is
+  // defined.
+  const uint8_t starting_hue = 192;
 
  protected:
   void setup(void) final;


### PR DESCRIPTION
In spite of the API taking uint16_t for the HSV parameters for hsv()
(which appears to be in order to retain compatibility with existing
plugins), the expected values are actually in the 0 ... 255 range.

Update calls to make sure values passed are within that range. This
did mean flattening out the value portion from 128 ... 255 to a flat
255, which isn't ideal, but I didn't have a better idea off the top of
my head.

The effect of this change is that there are no longer oddly flashing
colors while cycling through the ripple effect.

In addition I've added a starting_hue constant (set to a shade of
purple I like, but easily changed), and a compile time #ifdef that
controls whether or not to cycle hues, called
CONSTANT_HUE. Personally, I prefer the CONSTANT_HUE effect, which is
less blingy, but IMHO shows the ripple effect better. This should
probably be turned into a run time switch.